### PR TITLE
remove heroku from install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ services:
   - docker
 
 before_install:
-  - heroku container:login
   - cd movies
 
 deploy:
   provider: script
-  script: heroku container:push web -a hydra-movies; heroku container:release web -a hydra-movies
+  script: heroku container:login; heroku container:push web -a hydra-movies; heroku container:release web -a hydra-movies
 
 env:
   global:


### PR DESCRIPTION
fork Pull Requests cannot access secure environment variables on heroku so the login command will fail

moved to the deploy script, which only runs on master anyway